### PR TITLE
Remove ddragon and change champ select

### DIFF
--- a/conduit/GameDataProxy.cs
+++ b/conduit/GameDataProxy.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using WebSocketSharp.Server;
+
+namespace MimicConduit
+{
+    public class GameDataProxy : IDisposable
+    {
+        private readonly HttpServer server;
+        private readonly Uri baseUri;
+
+        private readonly NetworkCredential credentials;
+
+        public GameDataProxy(HttpServer server, int port, string pass)
+        {
+            this.server = server;
+            baseUri = new Uri($"https://127.0.0.1:{port}/");
+
+            credentials = new NetworkCredential("riot", pass);
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            server.OnGet += OnGetRequest;
+        }
+
+        private void OnGetRequest(object sender, HttpRequestEventArgs e)
+        {
+            var path = e.Request.Url.LocalPath;
+            if (!path.StartsWith("/lol-game-data/"))
+                return;
+
+            var proxyReq = WebRequest.CreateHttp(new Uri(baseUri, path));
+            proxyReq.ServerCertificateValidationCallback = ValidateCertificate;
+            proxyReq.Credentials = credentials;
+
+            using (e.Response)
+            using (var proxyRes = (HttpWebResponse) proxyReq.GetResponse())
+            using (var proxyStream = proxyRes.GetResponseStream())
+            using (var responseStream = e.Response.OutputStream)
+
+            using (var temp = new MemoryStream())
+            {
+                proxyStream?.CopyTo(temp);
+
+                e.Response.StatusCode = (int) proxyRes.StatusCode;
+                e.Response.ContentType = proxyRes.ContentType;
+                e.Response.ContentLength64 = temp.Length;
+                e.Response.AddHeader("Access-Control-Allow-Origin", "*");
+
+                temp.WriteTo(responseStream);
+            }
+
+            Console.WriteLine(path);
+        }
+
+        public void Dispose()
+        {
+            server.OnGet -= OnGetRequest;
+        }
+
+        private static bool ValidateCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            return true;
+        }
+    }
+}

--- a/conduit/LeagueSocketBehavior.cs
+++ b/conduit/LeagueSocketBehavior.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 using WebSocketSharp;
@@ -53,7 +54,16 @@ namespace MimicConduit
         private void handleWebSocketMessage(object sender, MessageEventArgs args)
         {
             if (!args.IsText) return;
-            var payload = SimpleJson.DeserializeObject<JsonArray>(args.Data);
+            JsonArray payload;
+            try
+            {
+                payload = SimpleJson.DeserializeObject<JsonArray>(args.Data);
+            }
+            catch (SerializationException)
+            {
+                var tmp = Regex.Replace(args.Data, "(\"spell(?:1|2)Id\"): \\d{5,}", "$1: 0");
+                payload = SimpleJson.DeserializeObject<JsonArray>(tmp);
+            }
 
             if (payload.Count != 3) return;
             if ((long)payload[0] != 8 || !((string)payload[1]).Equals("OnJsonApiEvent")) return;

--- a/conduit/MimicConduit.csproj
+++ b/conduit/MimicConduit.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GameDataProxy.cs" />
     <Compile Include="LeagueSocketBehavior.cs" />
     <Compile Include="ProcessExtensions.cs" />
     <Compile Include="SingleGlobalInstance.cs" />

--- a/web/src/components/champ-select/champ-select.ts
+++ b/web/src/components/champ-select/champ-select.ts
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import Root, { Result } from "../root/root";
 import { Component } from "vue-property-decorator";
-import { DDRAGON_VERSION, mapBackground, Role } from "../../constants";
+import { mapBackground, Role } from "../../constants";
 
 import Timer = require("./timer.vue");
 import Members = require("./members.vue");
@@ -16,6 +16,7 @@ export interface ChampSelectMember {
     cellId: number;
     championId: number;
     championPickIntent: number;
+    selectedSkinId: number;
     displayName: string;
     spell1Id: number;
     spell2Id: number;
@@ -81,8 +82,8 @@ export default class ChampSelect extends Vue {
     gameflowState: GameflowState | null = null;
 
     // These two are used to map summoner/champion id -> data.
-    championDetails: { [id: number]: { id: string, key: string, name: string } };
-    summonerSpellDetails: { [id: number]: { id: string, key: string, name: string } };
+    championDetails: { [id: number]: { id: string, name: string, squarePortraitPath: string } };
+    summonerSpellDetails: { [id: number]: { id: string, name: string, iconPath: string } };
 
     // Information for the summoner spell overlay.
     pickingSummonerSpell = false;
@@ -92,17 +93,17 @@ export default class ChampSelect extends Vue {
     pickingChampion = false;
 
     mounted() {
-        this.loadStatic("champion.json").then(map => {
+        this.loadStatic("champion-summary.json").then(list => {
             // map to { id: data }
             const details: any = {};
-            Object.keys(map.data).forEach(x => details[+map.data[x].key] = map.data[x]);
+            for (let champ of list) details[champ.id] = champ;
             this.championDetails = details;
         });
 
-        this.loadStatic("summoner.json").then(map => {
+        this.loadStatic("summoner-spells.json").then(list => {
             // map to { id: data }
             const details: any = {};
-            Object.keys(map.data).forEach(x => details[+map.data[x].key] = map.data[x]);
+            for (let spell of list) details[spell.id] = spell;
             this.summonerSpellDetails = details;
         });
 
@@ -189,7 +190,7 @@ export default class ChampSelect extends Vue {
     }
 
     /**
-     * Helper method to load the specified json name from the ddragon static data.
+     * Helper method to load the specified json name from the lol-game-data data.
      */
     private loadStatic(filename: string): Promise<any> {
         return new Promise(resolve => {
@@ -199,7 +200,7 @@ export default class ChampSelect extends Vue {
                 const map = JSON.parse(req.responseText);
                 resolve(map);
             };
-            req.open("GET", "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/data/en_GB/" + filename, true);
+            req.open("GET", this.$root.resolve("/lol-game-data/assets/v1/" + filename), true);
             req.send();
         });
     }

--- a/web/src/components/champ-select/champion-picker.ts
+++ b/web/src/components/champ-select/champion-picker.ts
@@ -2,7 +2,6 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { ChampSelectAction, ChampSelectState, default as ChampSelect } from "./champ-select";
 import Root from "../root/root";
-import { DDRAGON_VERSION } from "../../constants";
 
 @Component
 export default class ChampionPicker extends Vue {
@@ -142,6 +141,7 @@ export default class ChampionPicker extends Vue {
      * @returns the path to the icon of the specified champion
      */
     getChampionImage(id: number) {
-        return "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/img/champion/" + this.$parent.championDetails[id].id + ".png";
+        let champ = this.$parent.championDetails[id];
+        return this.$root.resolve(champ.squarePortraitPath);
     }
 }

--- a/web/src/components/champ-select/members.ts
+++ b/web/src/components/champ-select/members.ts
@@ -1,10 +1,12 @@
 import Vue from "vue";
+import Root, { Result } from "../root/root";
 import { Component, Prop } from "vue-property-decorator";
 import { default as ChampSelect, ChampSelectState, ChampSelectMember } from "./champ-select";
-import { DDRAGON_VERSION, POSITION_NAMES } from "../../constants";
+import { POSITION_NAMES } from "../../constants";
 
 @Component
 export default class Members extends Vue {
+    $root: Root;
     $parent: ChampSelect;
 
     @Prop
@@ -17,9 +19,9 @@ export default class Members extends Vue {
         const act = this.$parent.getActions(member);
         const champId = (act ? act.championId : 0) || member.championId || member.championPickIntent;
         if (!champId) return "background-color: transparent;";
-        const champ = this.$parent.championDetails[champId];
+        const skinId = member.selectedSkinId || (member.championId * 1000)
         const fade = champId === member.championPickIntent ? "opacity: 0.6;" : "";
-        return "background-image: url(http://ddragon.leagueoflegends.com/cdn/img/champion/splash//" + champ.id + "_0.jpg);" + fade;
+        return "background-image: url('" + this.$root.resolve("/lol-game-data/assets/v1/champion-splashes/" + champId + "/" + skinId + ".jpg") +"');" + fade;
     }
 
     /**
@@ -58,6 +60,7 @@ export default class Members extends Vue {
      * @returns the url to the icon for the specified summoner icon id
      */
     getSummonerSpellImage(id: number): string {
-        return "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/img/spell/" + this.$parent.summonerSpellDetails[id].id + ".png";
+        let spell = this.$parent.summonerSpellDetails[id];
+        return this.$root.resolve(spell.iconPath);
     }
 }

--- a/web/src/components/champ-select/members.vue
+++ b/web/src/components/champ-select/members.vue
@@ -1,21 +1,21 @@
 <template>
-    <div class="scrollable-content">
+    <div class="members">
         <div class="team">
             <span class="team-name">Your Team</span>
             <div class="team-member my" v-for="member in state.myTeam">
                 <div class="member-background" :style="getBackgroundStyle(member)"></div>
                 <div class="active-background" :class="getActiveOverlayClass(member)"></div>
-                <div class="summoner-spells">
-                    <img :src="getSummonerSpellImage(member.spell1Id)">
-                    <img :src="getSummonerSpellImage(member.spell2Id)">
-                </div>
                 <div class="info">
                     <span class="name">{{ member.displayName }}</span>
                     <span class="state">{{ getMemberSubtext(member) }}</span>
                 </div>
+                <div class="summoner-spells" v-if="member.spell1Id != 0 || member.spell2Id != 0">
+                    <img v-if="member.spell1Id != 0" :src="getSummonerSpellImage(member.spell1Id)">
+                    <img v-if="member.spell2Id != 0" :src="getSummonerSpellImage(member.spell2Id)">
+                </div>
             </div>
         </div>
-
+    
         <div class="team enemy-team" v-if="state.theirTeam.length > 0">
             <span class="team-name">Enemy Team</span>
             <div class="team-member enemy" v-for="member in state.theirTeam">
@@ -35,51 +35,60 @@
 <style lang="stylus" scoped>
     @require "./style.styl"
 
-    .scrollable-content
-        // String interpolation is needed because variables are ignored in calc.
+    .members
         max-height "calc(100% - %s)" % (timer-status-height + player-settings-height)
         min-height "calc(100% - %s)" % (timer-status-height + player-settings-height)
-        overflow-y scroll
+
+        display flex
         -webkit-overflow-scrolling touch // smooth scrolling on ios
 
     .team
+        flex 0 0 50%
         display flex
         flex-direction column
-        padding-top 20px
 
     .team-name
         padding 5px 20px
-        height 50px
+        flex 0 0 50px
         font-size 40px
         color #f0e6d2
         letter-spacing 0.05em
         font-family "LoL Display Bold"
+        text-align center
         text-transform uppercase
 
     .team-member
-        height team-member-height
+        flex 1
+        max-height 400px
         box-sizing border-box
         border-bottom 1px solid #cdbe93
         position relative
         display flex
-        align-items center
+        flex-direction column
+        align-items flex-start
+        justify-content space-between
         color white
 
         &:first-of-type
             border-top 1px solid #cdbe93
 
+    .enemy
+        flex-direction row-reverse
+
     .summoner-spells
-        margin 10px 20px
+        margin 10px 10px
         display flex
         flex-direction column
         align-items center
         justify-content space-around
 
         img
-            width 60px
-            height 60px
+            width 64px
+            height 64px
+            margin-top 10px
 
     .info
+        margin 5px 20px
         display flex
         flex-direction column
         font-family "LoL Body"
@@ -89,16 +98,15 @@
 
         .state
             display inline-block
-            height 30px
             transition 0.3s ease
             font-size 30px
             color #fffaef
 
         .state:empty
             height 0
-
+    
     .enemy .info
-        margin-left 20px
+        align-items: flex-end;
 
     .member-background
         position absolute
@@ -108,8 +116,8 @@
         bottom 0
         right 0
         background-repeat no-repeat
-        background-position 0 -80px
-        background-size cover
+        background-position 40% 8%
+        background-size 200%
         transition 0.3s ease
 
         &:after
@@ -120,6 +128,9 @@
             bottom 0
             right 0
             background-image linear-gradient(to left, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.4) 100%)
+
+    .enemy .member-background
+        background-position-x 60%
 
     @keyframes champ-select-active-background
         0% { background-position: 100% 0; }

--- a/web/src/components/champ-select/player-settings.ts
+++ b/web/src/components/champ-select/player-settings.ts
@@ -1,7 +1,6 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { ChampSelectState, default as ChampSelect } from "./champ-select";
-import { DDRAGON_VERSION } from "../../constants";
 import Root from "../root/root";
 
 @Component
@@ -60,6 +59,7 @@ export default class PlayerSettings extends Vue {
      * @returns the url to the icon for the specified summoner icon id
      */
     getSummonerSpellImage(id: number): string {
-        return "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/img/spell/" + this.$parent.summonerSpellDetails[id].id + ".png";
+        let spell = this.$parent.summonerSpellDetails[id];
+        return this.$root.resolve(spell.iconPath);
     }
 }

--- a/web/src/components/champ-select/summoner-picker.ts
+++ b/web/src/components/champ-select/summoner-picker.ts
@@ -2,7 +2,6 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { ChampSelectState, default as ChampSelect } from "./champ-select";
 import Root from "../root/root";
-import { DDRAGON_VERSION } from "../../constants";
 
 @Component
 export default class SummonerPicker extends Vue {
@@ -63,6 +62,7 @@ export default class SummonerPicker extends Vue {
      * @returns the url to the icon for the specified summoner icon id
      */
     getSummonerSpellImage(id: number): string {
-        return "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/img/spell/" + this.$parent.summonerSpellDetails[id].id + ".png";
+        let spell = this.$parent.summonerSpellDetails[id];
+        return this.$root.resolve(spell.iconPath);
     }
 }

--- a/web/src/components/champ-select/timer.ts
+++ b/web/src/components/champ-select/timer.ts
@@ -1,10 +1,11 @@
 import Vue from "vue";
+import Root from '../root/root';
 import { Component, Prop, Watch } from "vue-property-decorator";
 import { default as ChampSelect, ChampSelectState, ChampSelectTimer, ChampSelectAction } from "./champ-select";
-import { DDRAGON_VERSION } from "../../constants";
 
 @Component
 export default class Timer extends Vue {
+    $root: Root;
     $parent: ChampSelect;
 
     @Prop
@@ -72,7 +73,8 @@ export default class Timer extends Vue {
      * @returns the path to the icon for the specified champion id
      */
     getChampionIcon(id: number) {
-        return "http://ddragon.leagueoflegends.com/cdn/" + DDRAGON_VERSION + "/img/champion/" + this.$parent.championDetails[id].id + ".png";
+        let champ = this.$parent.championDetails[id];
+        return this.$root.resolve(champ.squarePortraitPath);
     }
 
     @Watch("state.timer")

--- a/web/src/components/invites/invites.ts
+++ b/web/src/components/invites/invites.ts
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import Root from "../root/root";
 import { Component } from "vue-property-decorator";
-import { DDRAGON_VERSION, MAPS, QUEUES } from "../../constants";
+import { MAPS, QUEUES } from "../../constants";
 
 interface Invite {
     id: string;
@@ -75,6 +75,6 @@ export default class Invites extends Vue {
      * @returns the path to the summoner icon for the inviter
      */
     getSummonerIcon(invite: Invite): string {
-        return `http://ddragon.leagueoflegends.com/cdn/${DDRAGON_VERSION}/img/profileicon/${invite.fromSummoner.profileIconId}.png`;
+        return this.$root.resolve("/lol-game-data/assets/v1/profile-icons" + invite.fromSummoner.profileIconId + ".jpg"); 
     }
 }

--- a/web/src/components/lobby/lobby-member.vue
+++ b/web/src/components/lobby/lobby-member.vue
@@ -33,9 +33,10 @@
 
 <script lang="ts">
     import Vue from "vue";
+    import Root from '../root/root';
     import { Component, Prop } from "vue-property-decorator";
     import { LobbyMember } from "./lobby";
-    import { DDRAGON_VERSION, POSITION_NAMES, roleImage as constantRoleImage } from "../../constants";
+    import { POSITION_NAMES, roleImage as constantRoleImage } from "../../constants";
 
     @Component
     export default class LobbyMemberComponent extends Vue {
@@ -48,8 +49,10 @@
         @Prop()
         showModeration: boolean;
 
+        $root: Root;
+
         get summonerIcon(): string {
-            return `http://ddragon.leagueoflegends.com/cdn/${DDRAGON_VERSION}/img/profileicon/${this.member.summoner.profileIconId}.png`;
+            return this.$root.resolve("/lol-game-data/assets/v1/profile-icons/" + this.member.summoner.profileIconId + ".jpg");
         }
 
         get positions(): string {

--- a/web/src/components/lobby/lobby.ts
+++ b/web/src/components/lobby/lobby.ts
@@ -150,7 +150,8 @@ export default class Lobby extends Vue {
      * @returns the current queue dodge timer, or -1 if there is none
      */
     get queueDodgeTime(): number {
-        return this.matchmakingState!.errors.reduce((p, c) => c.penaltyTimeRemaining > p ? c.penaltyTimeRemaining : p, -1);
+        if (!this.matchmakingState) return -1;
+        return this.matchmakingState.errors.reduce((p, c) => c.penaltyTimeRemaining > p ? c.penaltyTimeRemaining : p, -1);
     }
 
     /**

--- a/web/src/components/root/root.ts
+++ b/web/src/components/root/root.ts
@@ -52,6 +52,14 @@ export default class Root extends Vue {
     }
 
     /**
+     * Resolves a full uri at the Conduit's host/port from a path
+     */
+    resolve(path: string) {
+        if (path[0] != '/') path = '/' + path;
+        return "http://" + this.hostname + ":8182" + path;
+    }
+
+    /**
      * Starts observing the specified url. The handler will be called
      * whenever the endpoints contents or HTTP status change. Only a single
      * instance can observe the same path at a time.

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,5 +1,3 @@
-export const DDRAGON_VERSION = "7.11.1";
-
 export const QUEUES: { [key: number]: string } = {
     2: "Normal 5v5",
     8: "Normal 3v3",


### PR DESCRIPTION
* Add GameDataProxy which allows access to the /lol-game-data/assets/ endpoints

* Remove all references to ddragon and replace them with lol-game-data

* Changed layout of champ select using new lol-game-data centered splash arts

* Fixed an obsure bug where bots have summoner spell ids equal to 2^64-1 and this breaks SimpleJson :(