### PR TITLE
Add .NET framework check

### DIFF
--- a/conduit/AboutWindow.xaml
+++ b/conduit/AboutWindow.xaml
@@ -23,7 +23,8 @@
             <Run Text="on your phone and enter the following code:"/>
         </TextBlock>
         <Label x:Name="CodeLabel" Content="562414" HorizontalAlignment="Left" Margin="148,107,0,0" VerticalAlignment="Top" Width="336" FontFamily="Courier New" FontSize="50" HorizontalContentAlignment="Center" Height="64" VerticalContentAlignment="Center" Visibility="Hidden"/>
-        <TextBlock x:Name="NoCodeText" Margin="15,46,15,0" TextWrapping="Wrap" VerticalAlignment="Top" RenderTransformOrigin="-0.122,0.378" FontSize="14"><Run Text="To control League from your phone, please launch League at least once while Conduit is running."/><Run Text=" After that, check back here for instructions on how to connect to "/><Run Text="League from your phone."/></TextBlock>
+        <TextBlock x:Name="NoCodeText" Margin="15,46,15,0" TextWrapping="Wrap" VerticalAlignment="Top" RenderTransformOrigin="-0.122,0.378" FontSize="14" Visibility="Hidden"><Run Text="To control League from your phone, please launch League at least once while Conduit is running."/><Run Text=" After that, check back here for instructions on how to connect to "/><Run Text="League from your phone."/></TextBlock>
+        <TextBlock x:Name="NoDotNetText" Margin="15,46,15,0" TextWrapping="Wrap" VerticalAlignment="Top" RenderTransformOrigin="-0.122,0.378" FontSize="14"><Run Text="To control League from your phone, please install latest .NET framework."/><Run Text=" To do that visit "/><Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?LinkId=2085155">this</Hyperlink><Run Text=" link to download and then install downloaded executable. Mimic needs to be restarted after this process is finished."/></TextBlock>
         <CheckBox x:Name="StartOnStartupCheckbox" Content="Launch Mimic when your computer starts" HorizontalAlignment="Left" Margin="15,0,0,45" Height="15" VerticalAlignment="Bottom" FontSize="13" Click="HandleStartupChange" />
     </Grid>
 </Window>

--- a/conduit/AboutWindow.xaml.cs
+++ b/conduit/AboutWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using QRCoder;
+﻿using Microsoft.Win32;
+using QRCoder;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -26,6 +27,21 @@ namespace Conduit
                 RenderCode();
             }
             Persistence.OnHubCodeChanged += RenderCode;
+
+            CheckDotnet();
+        }
+
+        /**
+         * Checks if .NET framework is installed on this PC
+         */
+        private void CheckDotnet()
+        {
+            var version = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", null);
+            if ((int)version >= 394254) // .NET 4.6.1
+            {
+                NoDotNetText.Visibility = Visibility.Hidden;
+                NoCodeText.Visibility = Visibility.Visible;
+            }
         }
 
         /**


### PR DESCRIPTION
Since a lot of people seem to have trouble with reading that they need to install .NET framework I decided to add this functionality to Mimic itself. This could be done by bundling .NET redistributable installer, but it would require Mimic installer (`.msi` style), which I didn't want to do.