### PR TITLE
Removes white background for rounded home icons

### DIFF
--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -30,7 +30,8 @@
     }, {
         "src": "icons/icon-192x192.png",
         "sizes": "192x192",
-        "type": "image/png"
+        "type": "image/png",
+        "purpose": "any maskable"
     }, {
         "src": "icons/icon-384x384.png",
         "sizes": "384x384",


### PR DESCRIPTION
This minor update attempts to make installs in mobile devices that use round icons look better. Essentially removing the white background that can be seen here
![image](https://user-images.githubusercontent.com/253405/85228515-cbeb4c00-b3b1-11ea-998c-3b890777bd89.png)
